### PR TITLE
Bugfix/random-seed-for-pytorch>=1.6

### DIFF
--- a/data/vimeo90k.py
+++ b/data/vimeo90k.py
@@ -44,10 +44,13 @@ class VimeoTriplet(Dataset):
         if self.training:
             seed = random.randint(0, 2**32)
             random.seed(seed)
+            torch.manual_seed(seed)
             img1 = self.transforms(img1)
             random.seed(seed)
+            torch.manual_seed(seed)
             img2 = self.transforms(img2)
             random.seed(seed)
+            torch.manual_seed(seed)
             img3 = self.transforms(img3)
             # Random Temporal Flip
             if random.random() >= 0.5:


### PR DESCRIPTION
Hello,

I wanted to report an issue that I encountered while training on the Vimeo90k dataset using PyTorch 1.6 or higher, and I believe it to be a bug.

The problem arises from the fact that the random seed is no longer fixed with the __'random.seed(seed)'__ code in PyTorch versions 1.6 and later. As a result, the training process does not work as expected.

To address this issue, I propose a simple fix by adding __'torch.manual_seed(seed)'__ to the code. By including this line, the random seed will be properly set, leading to consistent and reliable training results.

I have tested this solution with PyTorch 2.0 and CUDA 12.0, and I can confirm that the code works flawlessly after implementing this fix.

Best regards,
Jihoon Nam